### PR TITLE
fix: New book screen doesn't respect "read tab first" setting

### DIFF
--- a/lib/ui/books_screen/books_screen.dart
+++ b/lib/ui/books_screen/books_screen.dart
@@ -750,7 +750,9 @@ class _BooksScreenState extends State<BooksScreen>
   }
 
   BookStatus _getStatusForNewBook() {
-    if (_tabController.index == 1) {
+    final inProgressIndex = readTabFirst ? 1 : 0;
+
+    if (_tabController.index == inProgressIndex) {
       return BookStatus.inProgress;
     } else if (_tabController.index == 2) {
       return BookStatus.forLater;


### PR DESCRIPTION
Thank you for this amazing app :) This is just a small fix for #572.