### PR TITLE
fix: correctly sort books with a half-star rating.

### DIFF
--- a/lib/ui/books_screen/books_screen.dart
+++ b/lib/ui/books_screen/books_screen.dart
@@ -396,8 +396,7 @@ class _BooksScreenState extends State<BooksScreen>
     }
 
     booksRated.sort((a, b) {
-      int ratingSorting = removeDiacritics(a.rating!.toString().toLowerCase())
-          .compareTo(removeDiacritics(b.rating!.toString().toLowerCase()));
+      int ratingSorting = a.rating!.compareTo(b.rating!);
       if (!isAsc) {
         ratingSorting *= -1;
       } // descending


### PR DESCRIPTION
When sorting by rating, books with a rating of a half-star aren't sorted correctly.

This was due to the ratings being converted to strings and those strings used for sorting. A half-star is stored as 5, which means that the string gets sorted as being above anything starting with 4 or less. I.e. anything but a full five stars.

This has been fixed by doing the comparison on the int directly.