### PR TITLE
fix: Books without readings being spuriously included in statistics.

### DIFF
--- a/lib/logic/bloc/stats_bloc/stats_bloc.dart
+++ b/lib/logic/bloc/stats_bloc/stats_bloc.dart
@@ -279,6 +279,10 @@ class StatsBloc extends Bloc<StatsEvent, StatsState> {
       if (book.pages == null || book.pages! == 0) continue;
 
       if (book.readings.isEmpty) {
+        if (year != null) {
+          continue;
+        }
+
         if (shortestBookPages == null || book.pages! < shortestBookPages) {
           shortestBookPages = book.pages!;
           shortestBookString = '${book.title} - ${book.author}';
@@ -343,6 +347,10 @@ class StatsBloc extends Bloc<StatsEvent, StatsState> {
       if (book.pages == null || book.pages! == 0) continue;
 
       if (book.readings.isEmpty) {
+        if (year != null) {
+          continue;
+        }
+
         if (longestBookPages == null || book.pages! > longestBookPages) {
           longestBookPages = book.pages!;
           longestBookString = '${book.title} - ${book.author}';
@@ -472,6 +480,10 @@ class StatsBloc extends Bloc<StatsEvent, StatsState> {
       if (book.pages == null) continue;
 
       if (book.readings.isEmpty) {
+        if (year != null) {
+          continue;
+        }
+
         finishedPages += book.pages!;
         countedBooks += 1;
       } else {


### PR DESCRIPTION
It was the case that books without recorded readings would be included in some of the statistics for a specific year. Specifically the shortest/longest, and average pages statistics.
It now will only include these books in overall statistics where a specific year isn't provided.