### PR TITLE
chore: pin macOS runner to version 14 for stable iOS builds

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -51,7 +51,7 @@ jobs:
 
   ios_build:
     name: iOS ipa
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
     - uses: subosito/flutter-action@v2


### PR DESCRIPTION
This PR pins the macOS runner version to 14 to ensure reliable iOS builds in CI/CD pipelines.

  Why this change:
  - macOS 15 runners have incomplete iOS SDK installations causing build failures
  (https://github.com/actions/runner-images/issues/12758)
  - macOS 14 provides stable, tested iOS development environment

  Why version pinning is good practice:
  - Reproducible builds: Ensures consistent build environment across all CI runs
  - Prevents breaking changes: Avoids automatic upgrades that can introduce compatibility issues
  - Faster debugging: Eliminates environment variables when troubleshooting build failures
  - Team alignment: All developers and CI use the same tested configuration