### PR TITLE
fix: expand text and add ellipsis when only_editions_with_covers too large

### DIFF
--- a/lib/ui/search_ol_editions_screen/search_ol_editions_screen.dart
+++ b/lib/ui/search_ol_editions_screen/search_ol_editions_screen.dart
@@ -114,9 +114,13 @@ class _SearchOLEditionsScreenState extends State<SearchOLEditionsScreen> {
                         },
                       ),
                       const SizedBox(width: 10),
-                      Text(
-                        LocaleKeys.only_editions_with_covers.tr(),
-                        style: const TextStyle(fontSize: 16),
+                      Expanded(
+                        child: Text(
+                          LocaleKeys.only_editions_with_covers.tr(),
+                          style: const TextStyle(fontSize: 16),
+                          overflow: TextOverflow.ellipsis,
+                          maxLines: 2,
+                        ),
                       )
                     ],
                   ),


### PR DESCRIPTION
BEFORE:

<img width="200" alt="IMG_8605" src="https://github.com/user-attachments/assets/c18217a1-1d7f-4128-80b8-59b5aa3ebca5" />

AFTER:

<img width="200" alt="IMG_8604" src="https://github.com/user-attachments/assets/7411a8a1-c934-42a5-9c86-bfbf2bd92bab" />
