### PR TITLE
fix: filter already set tags from tag list (#828)

### DIFF
--- a/lib/ui/add_book_screen/widgets/tags_text_field.dart
+++ b/lib/ui/add_book_screen/widgets/tags_text_field.dart
@@ -110,6 +110,7 @@ class TagsField extends StatelessWidget {
             Scrollbar(
               child: TypeAheadField(
                 controller: controller,
+                debounceDuration: Duration.zero,
                 itemBuilder: (context, suggestion) {
                   return Container(
                     color: Theme.of(context).colorScheme.surfaceVariant,
@@ -120,9 +121,18 @@ class TagsField extends StatelessWidget {
                 },
                 suggestionsCallback: (pattern) =>
                     allTags?.where((String option) {
+                      final selectedTags = context
+                              .read<EditBookCubit>()
+                              .state
+                              .tags
+                              ?.split('|||||')
+                              .where((t) => t.isNotEmpty)
+                              .toSet() ??
+                          <String>{};
                       return option
-                          .toLowerCase()
-                          .startsWith(pattern.toLowerCase());
+                              .toLowerCase()
+                              .startsWith(pattern.toLowerCase()) &&
+                          !selectedTags.contains(option);
                     }).toList() ??
                     [],
                 onSelected: (suggestion) {


### PR DESCRIPTION
## Description
Excludes tags already assigned to a book from the tag suggestions list.
Previously, when adding a tag, the suggestions dropdown would still show tags that were already applied to the current book.
Since selecting an already assigned tag doesn't add it to the book a second time, displaying it as a choice is redundant.

## Changes
- Filter `allTags` against the book's currently assigned tags, so already-applied tags no longer appear as suggestions.
- Add `debounceDuration: Duration.zero` so the suggestions list updates immediately after selecting a tag, avoiding a brief flash where an already-assigned tag would still appear.

## Testing
- Manually tested adding/removing tags on a book with several existing
  tags; confirmed already-assigned tags no longer show up while typing.
- Confirmed suggestions still appear correctly for an untagged book.

Closes #828